### PR TITLE
Refactor: inject influxdb api instead of NAS

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -25,7 +25,8 @@ App::App(int argc, char *argv[]) : QApplication(argc, argv),
     mWebSocketServer = new WebSocketServer(5000, "JuneServer");
     setApplicationName("June Server");
 
-    logValueData_ = new LogValueData(networkAcessManager_);
+    influxdb_.useDb("june");
+    logValueData_ = new LogValueData(influxdb_);
 
     QCommandLineParser parser;
     QCommandLineOption noGui(QStringList() << "g" << "no-gui", "Gui" );

--- a/app.h
+++ b/app.h
@@ -8,6 +8,7 @@
 
 #include <tagsystem/taglist.h>
 #include <tagsystem/tag.h>
+#include <influxdb/influxdb.h>
 
 #include "websocketserver.h"
 #include "mainwindow.h"
@@ -54,6 +55,7 @@ private:
     QTimer *mSystemTimeTimer = nullptr;
 
     PluginManager pluginManager_;
+    InfluxDB influxdb_ = InfluxDB(networkAcessManager_);
 };
 
 #endif // APP_H

--- a/logvaluedata.cpp
+++ b/logvaluedata.cpp
@@ -12,8 +12,8 @@
 
 #include <influxdb/influxdb.h>
 
-LogValueData::LogValueData(QNetworkAccessManager &networkAccessManager, QObject *parent) : QObject(parent),
-    networkAccessManager_(networkAccessManager)
+LogValueData::LogValueData(InfluxDB &influxDb, QObject *parent) : QObject(parent),
+    influxDb_(influxDb)
 {
     loadLogValueList();
 }
@@ -32,9 +32,9 @@ LogValueData::~LogValueData()
 void LogValueData::addLogValue(const QString &aTableName, const QString &aValueName, const QString &aTagSubSystem, const QString &TagName)
 {
 #ifdef __arm__
-    mLogValues.push_back(new LogValue(networkAccessManager_, aTableName, aValueName, aTagSubSystem, TagName));
+    mLogValues.push_back(new LogValue(influxDb_, aTableName, aValueName, aTagSubSystem, TagName));
 #else
-    mLogValues.push_back(std::make_unique<LogValue>(networkAccessManager_, aTableName, aValueName, aTagSubSystem, TagName));
+    mLogValues.push_back(std::make_unique<LogValue>(influxDb_, aTableName, aValueName, aTagSubSystem, TagName));
 #endif
     saveLogValueList();
     emit logValueAdded();
@@ -126,9 +126,9 @@ void LogValueData::loadLogValueList()
                 QString tagname = stream.attributes().value("tagname").toString();
 
 #ifdef __arm__
-                mLogValues.push_back(new LogValue(networkAccessManager_, table, tagname, TagSocket::typeFromString(type), tagsubsystem, tagname));
+                mLogValues.push_back(new LogValue(influxDb_, table, tagname, TagSocket::typeFromString(type), tagsubsystem, tagname));
 #else
-                mLogValues.push_back(std::make_unique<LogValue>(networkAccessManager_, table, tagname, TagSocket::typeFromString(type), tagsubsystem, tagname));
+                mLogValues.push_back(std::make_unique<LogValue>(influxDb_, table, tagname, TagSocket::typeFromString(type), tagsubsystem, tagname));
 #endif
             }
         }
@@ -167,15 +167,14 @@ const LogValue *LogValueData::getLogValueByIndex(unsigned int aIndex) const
 
 
 
-LogValue::LogValue(QNetworkAccessManager &networkAccessManager, const QString &aTableName, const QString &aValueName, const QString &aTagSubSystem, const QString &aTagName) :
-    networkAccessManager_(networkAccessManager),
+LogValue::LogValue(InfluxDB &influxDb, const QString &aTableName, const QString &aValueName, const QString &aTagSubSystem, const QString &aTagName) :
+    influxdb_(influxDb),
     mTableName(aTableName),
     mValueName(aValueName),
     mTagSubSystem(aTagSubSystem),
     mTagName(aTagName),
     mLogValueTagSocket(nullptr)
 {
-    influxdb_.useDb("june");
     QString tagname = QString("%1.%2").arg(aTagSubSystem).arg(aTagName);
     Tag *tag = TagList::sGetInstance().findByTagName(tagname);
 
@@ -185,15 +184,14 @@ LogValue::LogValue(QNetworkAccessManager &networkAccessManager, const QString &a
     connect(mLogValueTagSocket, qOverload<TagSocket*>(&TagSocket::valueChanged), this, &LogValue::onTagSocketValueChanged);
 }
 
-LogValue::LogValue(QNetworkAccessManager &networkAccessManager, const QString &aTableName, const QString &aValueName, TagSocket::Type aType, const QString &aTagSubSystem, const QString &aTagName) :
-    networkAccessManager_(networkAccessManager),
+LogValue::LogValue(InfluxDB &influxDb, const QString &aTableName, const QString &aValueName, TagSocket::Type aType, const QString &aTagSubSystem, const QString &aTagName) :
+    influxdb_(influxDb),
     mTableName(aTableName),
     mValueName(aValueName),
     mTagSubSystem(aTagSubSystem),
     mTagName(aTagName),
     mLogValueTagSocket(nullptr)
 {
-    influxdb_.useDb("june");
     mLogValueTagSocket = TagSocket::createTagSocket(aTableName, aValueName, aType);
     mLogValueTagSocket->hookupTag(aTagSubSystem, aTagName);
     connect(mLogValueTagSocket, qOverload<TagSocket*>(&TagSocket::valueChanged), this, &LogValue::onTagSocketValueChanged);

--- a/logvaluedata.h
+++ b/logvaluedata.h
@@ -9,13 +9,12 @@
 #include <influxdb/influxdb.h>
 
 class LogValue;
-class QNetworkAccessManager;
 
 class LogValueData : public QObject
 {
     Q_OBJECT
 public:
-    explicit LogValueData(QNetworkAccessManager &networkAccessManager, QObject *parent = nullptr);
+    explicit LogValueData(InfluxDB &influxDb, QObject *parent = nullptr);
 #ifdef __arm__
     ~LogValueData();
 #endif
@@ -34,7 +33,7 @@ signals:
     void logValueListLoaded();
 
 private:
-    QNetworkAccessManager &networkAccessManager_;
+    InfluxDB &influxDb_;
 #ifdef __arm__
     std::vector<LogValue*> mLogValues;
 #else
@@ -47,8 +46,8 @@ class LogValue : public QObject
 {
     Q_OBJECT
 public:
-    LogValue(QNetworkAccessManager &networkAccessManager, const QString &aTableName, const QString &aValueName, const QString &aTagSubSystem, const QString &aTagName);
-    LogValue(QNetworkAccessManager &networkAccessManager, const QString &aTableName, const QString &aValueName, TagSocket::Type aType, const QString &aTagSubSystem, const QString &aTagName);
+    LogValue(InfluxDB &infuxDb, const QString &aTableName, const QString &aValueName, const QString &aTagSubSystem, const QString &aTagName);
+    LogValue(InfluxDB &infuxDb, const QString &aTableName, const QString &aValueName, TagSocket::Type aType, const QString &aTagSubSystem, const QString &aTagName);
 
     const QString& getTableName() const;
     const QString& getValueNAme() const;
@@ -60,15 +59,13 @@ private slots:
     void onTagSocketValueChanged(TagSocket *aTagSocket);
 
 private:
-    QNetworkAccessManager &networkAccessManager_;
+    InfluxDB &influxdb_;
 
     QString mTableName;
     QString mValueName;
     QString mTagSubSystem;
     QString mTagName;
     TagSocket* mLogValueTagSocket;
-
-    InfluxDB influxdb_ = InfluxDB(networkAccessManager_);
 };
 
 #endif // LOGVALUEDATA_H


### PR DESCRIPTION
Put the influxDB communications to app.h, and inject it into logging instead of injecting network acsess manager. Easier to manipulate it with command line argument in the future.