### PR TITLE
Trigger only once every day

### DIFF
--- a/automation/trigger/triggerontime.cpp
+++ b/automation/trigger/triggerontime.cpp
@@ -26,6 +26,8 @@ void TriggerOnTime::update(const QJsonObject &obj)
     {
         duration_ = obj.value("duration").toInt();
     }
+
+    resetState();
 }
 
 TriggerType TriggerOnTime::type() const
@@ -44,14 +46,40 @@ void TriggerOnTime::tagSocketValueChanged(TagSocket *tagSocket)
 
     int tagSocketTimeOfDayValue = value.time().msecsSinceStartOfDay();
 
-    if(tagSocketTimeOfDayValue > triggerTimeOfDay_)
+    // reset at start of day, first 2 sec after midnight
+    if(tagSocketTimeOfDayValue < 2000)
     {
-        if(!isActive())
-            setActive();
+        resetState();
     }
 
-    if(isActive() && duration_ > 0 && tagSocketTimeOfDayValue > (triggerTimeOfDay_ + duration_))
+    if(!hasTriggeredOn_
+        && tagSocketTimeOfDayValue > triggerTimeOfDay_
+        && tagSocketTimeOfDayValue < (triggerTimeOfDay_ + duration_))
     {
-        setDeactive();
+        if(!isActive())
+        {
+            setActive();
+            hasTriggeredOn_ = true;
+        }
     }
+
+    if(!hasTriggeredOff_
+        && isActive()
+        && duration_ > 0
+        && tagSocketTimeOfDayValue > (triggerTimeOfDay_ + duration_))
+    {
+        if(isActive())
+        {
+            setDeactive();
+            hasTriggeredOff_ = true;
+        }
+    }
+}
+
+void TriggerOnTime::resetState()
+{
+    hasTriggeredOn_ = false;
+    hasTriggeredOff_ = false;
+    if(isActive())
+        setDeactive();
 }

--- a/automation/trigger/triggerontime.h
+++ b/automation/trigger/triggerontime.h
@@ -18,10 +18,14 @@ protected:
     void tagSocketValueChanged(TagSocket *tagSocket) override;
 
 private:
+    void resetState();
+
     // seconds since midnight
     int triggerTimeOfDay_ = 0;
     // The time duration in minutes the trigger is active
     int duration_ = 0;
+    bool hasTriggeredOn_ = false;
+    bool hasTriggeredOff_ = false;
 };
 
 #endif // TRIGGERONTIME_H


### PR DESCRIPTION
Safeguard rules with flags to make sure they only trigger once, resets state at start of day (just after midnight), and reset state if trigger is updated.