### PR TITLE
Debug option for tag value updates

### DIFF
--- a/lib/app.cpp
+++ b/lib/app.cpp
@@ -47,7 +47,14 @@ App::App(int argc, char *argv[]) : QCoreApplication(argc, argv)
                                "file");
     parser.addOption(tagFile);
 
+    parser.addOption({{"d", "debug"}, "Debug mode. Print info when a tag value is updated."});
+
     parser.process(*this);
+
+    if (parser.isSet("debug"))
+    {
+        mWebSocketServer->setDebugTagValues();
+    }
 
     if (parser.isSet(tagFile))
     {

--- a/lib/websocketserver.cpp
+++ b/lib/websocketserver.cpp
@@ -79,6 +79,12 @@ void WebSocketServer::socketDisconnected()
 
 void WebSocketServer::onTagValueChanged(Tag *aTag)
 {
+    if (isTagValueDebug_)
+    {
+
+        qDebug() << aTag->getFullName() << " " << aTag->getTypeStr() << " value: " << aTag->getValueAsString();
+    }
+
     QJsonArray array;
     array.push_back(aTag->toJson());
     QJsonDocument document(array);

--- a/lib/websocketserver.h
+++ b/lib/websocketserver.h
@@ -27,6 +27,7 @@ class WebSocketServer : public QObject
 public:
     WebSocketServer(qint16 port, QString aServerName, QObject *parent=nullptr);
 
+    void setDebugTagValues() {isTagValueDebug_ = true;}
 signals:
     void newConnection(Client*);
 
@@ -43,6 +44,7 @@ private slots:
     void onClientDisconnect(Client *aClient);
 private:
     std::unique_ptr<QWebSocketServer> mWebSocketServer;
+    bool isTagValueDebug_ = false;
 
     QVector<Client*> mClients;
 };


### PR DESCRIPTION
When a tag is updated with a new value. Write it to console. Simplify development when verify that tags is updated without starting another application to watch the tags.